### PR TITLE
Httpuv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
 FROM r-base:4.0.0
 
-EXPOSE 50055
-
 RUN apt-get update && apt-get install -y npm libcurl4-openssl-dev libxml2-dev
 
 COPY build/install.R /app/build/install.R
 WORKDIR /app
 RUN Rscript build/install.R
 
-COPY package.json /app/package.json
-COPY package-lock.json /app/package-lock.json
-
-RUN npm install .
-
 COPY DESCRIPTION /app/DESCRIPTION
 COPY NAMESPACE /app/NAMESPACE
 COPY R/IsoplotR.R /app/R/IsoplotR.R
-COPY test /app/test
 COPY inst /app/inst
+COPY build/start-gui.R /app/build/start-gui.R
 
-CMD ["Rscript", "--vanilla", "test/start-gui.R", "0.0.0.0:50055"]
+EXPOSE 3838
+
+CMD ["Rscript", "--vanilla", "build/start-gui.R", "0.0.0.0:3838"]

--- a/README.md
+++ b/README.md
@@ -214,12 +214,6 @@ boot, or `-f` to show messages as they come in.
 
 As well as `journalctl`, there are logs from nginx at `var/log/nginx`.
 
-#### docker logs
-
-```sh
-docker logs isoplotrd
-```
-
 ## Further information
 
 See [http://isoplotr.london-geochron.com](http://ucl.ac.uk/~ucfbpve/isoplotr)


### PR DESCRIPTION
Removed RUN npm install .
Also the CMD line was wrong, and we didn't have the start-gui.R script.
More stuff could be removed.
Funnily enough, npm still needs to be apt installed, because devtools wants it.