### PR TITLE
Dockerfile corrected, README updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,8 @@ RUN Rscript build/install.R
 
 COPY DESCRIPTION /app/DESCRIPTION
 COPY NAMESPACE /app/NAMESPACE
-COPY R/IsoplotR.R /app/R/IsoplotR.R
+COPY R /app/R
 COPY inst /app/inst
 COPY build/start-gui.R /app/build/start-gui.R
 
-EXPOSE 3838
-
-CMD ["Rscript", "--vanilla", "build/start-gui.R", "0.0.0.0:3838"]
+CMD ["Rscript", "--vanilla", "build/start-gui.R", "0.0.0.0:80"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo useradd -mrU wwwrunner
 sudo adduser wwwrunner docker
 ```
 
-Clone and build (as `wwwrunner`):
+Pull (as `wwwrunner`):
 
 ```sh
 sudo -u wwwrunner docker pull pvermees/isoplotr
@@ -92,7 +92,7 @@ After=network.target
 [Service]
 Type=simple
 User=wwwrunner
-ExecStart=docker run --rm --name isoplotr -p 3838:80 isoplotr
+ExecStart=docker run --rm --name isoplotr -p 3838:80 pvermees/isoplotr
 Restart=always
 
 [Install]
@@ -164,6 +164,59 @@ Then add a line like this (to run at 03:17 local time):
 
 ```
 17 3 * * * docker pull pvermees/isoplotr && systemctl restart isoplotr
+```
+
+### Maintenance
+
+You can find logs for the various processes mentioned here in the
+following places:
+
+#### crontab logs
+
+```
+grep CRON < /var/log/syslog
+```
+
+or, if you want to see the messages as they appear:
+
+```
+tail -f /var/log/syslog | grep --line-buffered CRON
+```
+
+#### SystemD logs
+
+```sh
+journalctl -u isoplotr
+```
+
+and:
+
+```sh
+journalctl -u nginx
+```
+
+`journalctl` has many interesting options; for example `-r` to see
+the most recent messages first, `-k` to see messages only from this
+boot, or `-f` to show messages as they come in.
+
+#### nginx logs
+
+As well as `journalctl`, there are logs from nginx at `/var/log/nginx`.
+
+#### docker logs
+
+```sh
+docker logs isoplotr
+```
+
+## Updating
+
+We update the image (tagged `latest`) on docker hub with the following commands:
+
+```sh
+docker login
+docker build -t pvermees/isoplotr https://github.com/pvermees/IsoplotRgui.git
+docker push pvermees/isoplotr
 ```
 
 ## Further information

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ Pull (as `wwwrunner`):
 sudo -u wwwrunner docker pull pvermees/isoplotr
 ```
 
+#### (Without Docker Hub)
+
+If you cannot or do not want to use Docker Hub, the following will
+perform the image build on your machine:
+
+```sh
+docker build -t pvermees/isoplotr https://github.com/pvermees/IsoplotRgui.git
+```
+
 ### SystemD to keep *IsoplotR* running
 
 We will be using [SystemD](https:://systemd.io) to keep **IsoplotR**
@@ -165,6 +174,16 @@ Then add a line like this (to run at 03:17 local time):
 ```
 17 3 * * * docker pull pvermees/isoplotr && systemctl restart isoplotr
 ```
+
+#### (Without Docker Hub)
+
+Again, if you cannot or do not want to use Docker Hub, you can rebuild
+image on your machine:
+
+```
+17 3 * * * docker build --no-cache -t pvermees/isoplotr https://github.com/pvermees/IsoplotRgui.git && systemctl restart isoplotr
+```
+
 
 ### Maintenance
 


### PR DESCRIPTION
Dockerfile was a bit wrong, README needed some correcting.
Also added the "maintenance" section from docker-isoplotr, and added a little section about how we would update the image on docker hub (it's only three lines).

I investigated github packages for docker hosting and found that although it works pretty nicely, you need to give access to each individual that wants to pull the image, so probably not good from our point of view.
