### PR TITLE
Better instructions for removing old isoplotr docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ following lines into a file `/usr/local/sbin/isoplotr-start`:
 ```sh
 docker stop isoplotr
 docker rm isoplotr
-docker rmi $(docker images -qf dangling=true pvermees/isoplotr)
+docker images -qf dangling=true pvermees/isoplotr | xargs -r docker rmi
 docker run --restart unless-stopped -d --name isoplotr -p 3838:80 pvermees/isoplotr
 ```
 


### PR DESCRIPTION
Just that xargs thing to remove a spurious error in the logs