### PR TITLE
open browser on 127.0.0.1 by default, not 0.0.0.0

### DIFF
--- a/R/IsoplotR.R
+++ b/R/IsoplotR.R
@@ -129,7 +129,9 @@ IsoplotR <- function(host='0.0.0.0', port=NULL) {
             protocol <- ""
         }
         port <- s$getPort()
-        utils::browseURL(paste0(protocol, host, ":", port))
+        utils::browseURL(paste0(protocol,
+          if (host == '0.0.0.0') '127.0.0.1' else host,
+          ":", port))
         extraMessage <- "Call IsoplotRgui::stopIsoplotR() to stop serving IsoplotR\n"
     }
     cat(sprintf("Listening on %s:%d\n%s", host, port, extraMessage))


### PR DESCRIPTION
I'm not sure I like the state the IsoplotR() function is in at the moment, perhaps it should be simplified to always listen on 0.0.0.0 and browse to 127.0.0.1.
Anyway, here's a fix. The problem is that Windows doesn't let browsers connect to 127.0.0.1 when they ask for 0.0.0.0 whereas Linux does. Perhaps the Windows way is better...