### PR TITLE
Weblate 4.6 translation link fix

### DIFF
--- a/inst/www/js/languages.json
+++ b/inst/www/js/languages.json
@@ -19,5 +19,5 @@
             "short_name": "ES"
         }
     ],
-    "translation_link": "http://lgc.es.ucl.ac.uk/weblate/translate/isoplotrgui/${FILENAME}/${LANGUAGE}?q=context%3A.${ID}"
+    "translation_link": "http://lgc.es.ucl.ac.uk/weblate/translate/isoplotrgui/${FILENAME}/${LANGUAGE}?q=context%3A${ID}"
 }


### PR DESCRIPTION
Now searching for a translation string ID means just
searching for the ID without a . in front